### PR TITLE
Ignore styled-component mixin properties

### DIFF
--- a/src/rules/css-property-no-unknown/__tests__/index.js
+++ b/src/rules/css-property-no-unknown/__tests__/index.js
@@ -48,6 +48,10 @@ testRule(rule, {
       }
       `,
       description: "ignore properties inside ICSS :export pseudo-selector"
+    },
+    {
+      code: ".foo { -styled-mixin0: dummyValue; }",
+      description: "ignore styled-component mixins"
     }
   ],
 

--- a/src/rules/css-property-no-unknown/index.js
+++ b/src/rules/css-property-no-unknown/index.js
@@ -67,6 +67,10 @@ export default function(actual, options) {
         return;
       }
 
+      if (/^-styled-mixin\d+/.test(prop.toLowerCase())) {
+        return;
+      }
+
       utils.report({
         message: messages.rejected(prop),
         node: decl,


### PR DESCRIPTION
A fix for
https://github.com/kristerkari/stylelint-config-react-native-styled-components/issues/3

styled-components' stylelint processor injects some custom properties that need to be ignored:
https://github.com/styled-components/stylelint-processor-styled-components/blob/master/src/utils/tagged-template-literal.js